### PR TITLE
Checking for manual status change over "Expired" status

### DIFF
--- a/class-wc-gateway-bitcart.php
+++ b/class-wc-gateway-bitcart.php
@@ -46,6 +46,7 @@ function woocommerce_bitcart_init()
         {
             // General
             $this->id = 'bitcart';
+            $this->enabled = $this->get_option( 'enabled' );
             $this->icon = plugin_dir_url(__FILE__) . 'assets/img/icon.png';
             $this->has_fields = false;
             $this->order_button_text = __('Proceed to Bitcart', 'bitcart');
@@ -87,16 +88,18 @@ function woocommerce_bitcart_init()
             );
 
             // Valid for use and IPN Callback
-            if (false === $this->is_valid_for_use()) {
-                $this->enabled = 'no';
-                $this->log('    [Info] The plugin is NOT valid for use!');
-            } else {
-                $this->enabled = 'yes';
-                $this->log('    [Info] The plugin is ok to use.');
-                add_action('woocommerce_api_wc_gateway_bitcart', array(
-                    $this,
-                    'ipn_callback',
-                ));
+            if ($this->enabled === 'yes') {
+                if ($this->is_valid_for_use()) {
+                    $this->log('    [Info] The plugin is valid to use.');
+                    add_action('woocommerce_api_wc_gateway_bitcart', array(
+                        $this,
+                        'ipn_callback',
+                    ));
+                }else {
+                    $this->enabled = 'no';
+                    $this->log('    [Info] The plugin is NOT valid for use!');
+                    $this->log('    [Info] Please set the API URL, Store ID and Admin URL.');
+                }
             }
 
             $this->is_initialized = true;
@@ -150,6 +153,12 @@ function woocommerce_bitcart_init()
                 $log_file;
 
             $this->form_fields = array(
+                'enabled' => array(
+					'title' => __('Enable/Disable', 'bitcart'),
+					'type' => 'checkbox',
+					'label' => __('Enable Bitcart payment gateway', 'bitcart'),
+					'default' => 'false',
+				),
                 'title' => array(
                     'title' => __('Title', 'bitcart'),
                     'type' => 'text',

--- a/class-wc-gateway-bitcart.php
+++ b/class-wc-gateway-bitcart.php
@@ -836,6 +836,14 @@ function woocommerce_bitcart_init()
                     break;
 
                 case 'expired':
+                    // if the order is completed manually, do not change the status
+                    if ($current_status === 'completed') {
+                        $this->log(
+                            '    [Info] The order is already completed manually, skipping the cancellation...'
+                        );
+                        break;
+                    }
+
                     $this->log('    [Info] The invoice is in the "expired" status...');
                     $order->update_status(
                         'wc-cancelled',


### PR DESCRIPTION
sometimes it happens that I have to complete some orders manually during some partial payments and etc.
but after a hour, order status will change from "Completed" to "canceled" because of expired invoice.