### PR TITLE
Checking for manual status change over "Expired" status

### DIFF
--- a/class-wc-gateway-bitcart.php
+++ b/class-wc-gateway-bitcart.php
@@ -836,6 +836,14 @@ function woocommerce_bitcart_init()
                     break;
 
                 case 'expired':
+                    // if the order is completed manually, do not change the status
+                    if ($current_status === 'completed') {
+                        $this->log(
+                            '    [Info] The order is already completed manually, skipping the cancellation...'
+                        );
+                        break;
+                    }
+
                     $this->log('    [Info] The invoice is in the "expired" status...');
                     $order->update_status(
                         'wc-cancelled',


### PR DESCRIPTION
sometimes it happens that I have to complete some orders manually during some partial payments and etc.
but after a hour, order status will change from "Completed" to "canceled" because of expired invoice.